### PR TITLE
Доработка фильтрации searchBar

### DIFF
--- a/AnRickAndMorty/AndersenRickAndMorty/App/Global Model/API Model/Object.swift
+++ b/AnRickAndMorty/AndersenRickAndMorty/App/Global Model/API Model/Object.swift
@@ -27,7 +27,7 @@ struct Package: Codable {
 struct information: Codable {
     let next: String?
     let prev: String?
-    let pages: Int
+    let count: Int?
 }
 
 struct Response: Codable {

--- a/AnRickAndMorty/AndersenRickAndMorty/App/Global Model/Constants.swift
+++ b/AnRickAndMorty/AndersenRickAndMorty/App/Global Model/Constants.swift
@@ -20,6 +20,8 @@ enum APIconstants {
     static let locations: String = "https://rickandmortyapi.com/api/location/?page="
     static let episodes: String = "https://rickandmortyapi.com/api/episode/?page="
     static let charactersFilterName: String = "https://rickandmortyapi.com/api/character/?name="
+    static let locationsFilterName: String = "https://rickandmortyapi.com/api/location/?name="
+    static let episodesFilterName: String = "https://rickandmortyapi.com/api/episode/?name="
 }
 
 enum Colors {

--- a/AnRickAndMorty/AndersenRickAndMorty/App/Networking Service/NetManager.swift
+++ b/AnRickAndMorty/AndersenRickAndMorty/App/Networking Service/NetManager.swift
@@ -12,7 +12,7 @@ class NetManager {
         return NetManager()
     }
     
-    func fetchDataPage(url: String, page: Int, completion: @escaping ([Package], Int) -> ()) {
+    func fetchDataPage(url: String, page: Int, completion: @escaping ([Package]) -> ()) {
         let finalURL = url + String(page)
         
         guard let url = URL(string: finalURL) else { return }
@@ -28,13 +28,12 @@ class NetManager {
                 return
             }
             let result = list.results
-            let allPages = list.info.pages
-            completion(result, allPages)
+            completion(result)
         }
         task.resume()
     }
     
-    func fetchFilterDataPage(url: String, completion: @escaping ([Package], Int, String?) -> ()) {
+    func fetchFilterDataPage(url: String, completion: @escaping ([Package]?, String?) -> ()) {
     
         guard let url = URL(string: url) else { return }
         
@@ -46,28 +45,45 @@ class NetManager {
             
             guard let list = try? JSONDecoder().decode(Response.self, from: data) else {
                 print("Couldn't decode JSON")
+                let result = [Package]()
+                let nextPage: String? = nil
+                completion(result, nextPage)
                 return
             }
+            
             let result = list.results
-            let allPages = list.info.pages
             let nextPage = list.info.next
-            completion(result, allPages, nextPage ?? nil)
+            completion(result, nextPage ?? nil)
         }
         task.resume()
     }
     
     //MARK: DetailViewController
-    func getUrl(from title: String) -> String {
-        switch title {
-        case "Characters":
-            return APIconstants.characters
-        case "Locations":
-            return APIconstants.locations
-        case "Episodes":
-            return APIconstants.episodes
-        default:
-            print("Incorrect word in switch statement in DetailVC")
-            break
+    func getUrl(from title: String, isFiltering: Bool = false) -> String {
+        if isFiltering {
+            switch title {
+            case "Characters":
+                return APIconstants.charactersFilterName
+            case "Locations":
+                return APIconstants.locationsFilterName
+            case "Episodes":
+                return APIconstants.episodesFilterName
+            default:
+                print("Incorrect word in switch statement in DetailVC")
+                break
+            }
+        } else {
+            switch title {
+            case "Characters":
+                return APIconstants.characters
+            case "Locations":
+                return APIconstants.locations
+            case "Episodes":
+                return APIconstants.episodes
+            default:
+                print("Incorrect word in switch statement in DetailVC")
+                break
+            }
         }
         return ""
     }


### PR DESCRIPTION
Найден баг. Если прогрузить вручную все страницы АПИ (пролистать вниз все до упора) начать поиск, все удалить и снова начать поиск и сбросить до стартовой страницы, то по достижению конца АПИ начинает снова грузить страницы, происходит задвоение.
Думаю нужно изменить метод urlsession, чтобы он выдавал total количество объектов по запросу. Это нужно, чтобы сравнивать в методе detailViewController textDidChange количество элементов в массиве с общим количеством элементов и если они равны, возвращать isLoading = true, в другом случае false